### PR TITLE
use mouseup rather than mousedown for list selection

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -7,6 +7,11 @@ var List = function(component) {
   this.element = document.createElement('ul');
   this.element.className = 'suggestions';
 
+  // selectingListItem is set to true in the time between the mousedown and mouseup when clicking an item in the list
+  // mousedown on a list item will cause the input to blur which normally hides the list, so this flag is used to keep
+  // the list open until the mouseup
+  this.selectingListItem = false;
+
   component.el.parentNode.insertBefore(this.element, component.el.nextSibling);
   return this;
 };
@@ -59,11 +64,16 @@ List.prototype.drawItem = function(item, active) {
   this.element.appendChild(li);
 
   li.addEventListener('mousedown', function() {
-    this.handleMouseDown.call(this, item);
+    this.selectingListItem = true;
+  }.bind(this));
+
+  li.addEventListener('mouseup', function() {
+    this.handleMouseUp.call(this, item);
   }.bind(this));
 };
 
-List.prototype.handleMouseDown = function(item) {
+List.prototype.handleMouseUp = function(item) {
+  this.selectingListItem = false;
   this.component.value(item.original);
   this.clear();
   this.draw();

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -95,11 +95,14 @@ Suggestions.prototype.handleKeyDown = function(e) {
 };
 
 Suggestions.prototype.handleBlur = function() {
-  this.list.hide();
+  if (!this.list.selectingListItem) {
+    this.list.hide();
+  }
 };
 
 Suggestions.prototype.handleFocus = function() {
   if (!this.list.isEmpty()) this.list.show();
+  this.list.selectingListItem = false;
 };
 
 /**


### PR DESCRIPTION
This fixes https://github.com/mapbox/mapbox-gl-geocoder/issues/68 with background in https://github.com/mapbox/mapbox-gl-geocoder/issues/68#issuecomment-284943652.

One quirk I've noticed with this change is if you mousedown on a list item, then mouseup outside it correctly won't select it, but now the list stays open even when you interact with other elements of the page. I'm not sure the best fix for this but I don't think it's a big issue.