### PR TITLE
Untrap tab key events

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -55,8 +55,7 @@ Suggestions.prototype.handleKeyUp = function(keyCode) {
   if (keyCode === 40 ||
       keyCode === 38 ||
       keyCode === 27 ||
-      keyCode === 13 ||
-      keyCode === 9) return;
+      keyCode === 13 ) return;
 
   this.handleInputChange(this.el.value);
 };
@@ -64,7 +63,6 @@ Suggestions.prototype.handleKeyUp = function(keyCode) {
 Suggestions.prototype.handleKeyDown = function(e) {
   switch (e.keyCode) {
     case 13: // ENTER
-    case 9: // TAB
       if (!this.list.isEmpty()) {
         if (this.list.isVisible()) {
           e.preventDefault();


### PR DESCRIPTION
This PR addresses the accessibility limitations described in https://github.com/mapbox/mapbox-gl-geocoder/issues/162. Specifically, it removes special handling of `tab` events so that tabs can function normally to navigate among other elements on the page. 

\cc @tristen @katydecorah 