### PR TITLE
Add error rendering method so arbitrary text can be displayed

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -96,4 +96,13 @@ List.prototype.next = function() {
   this.move(this.active === this.items.length - 1 ? 0 : this.active + 1);
 };
 
+List.prototype.drawError = function(msg){
+  var li = document.createElement('li');
+
+  li.innerHTML = msg;
+
+  this.element.appendChild(li);
+  this.show();
+}
+
 module.exports = List;

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -244,4 +244,12 @@ Suggestions.prototype.render = function(item, sourceFormatting) {
   return boldString
 }
 
+/**
+ * Render an custom error message in the suggestions list
+ * @param {String} msg An html string to render as an error message
+ */
+Suggestions.prototype.renderError = function(msg){
+  this.list.drawError(msg);
+}
+
 module.exports = Suggestions;

--- a/test/test.js
+++ b/test/test.js
@@ -304,6 +304,17 @@ test('Suggestion.render [filter with sourceformatted text]', function(t) {
   t.end();
 });
 
+test('suggestion.renderError', function(t){
+  var parent = document.createElement('div');
+  var input = document.createElement('input');
+  parent.appendChild(input)
+  var typeahead = new Suggestions(input, [], {filter: false});
+  typeahead.renderError("This is a test");
+  var firstItem = parent.querySelectorAll('ul li').item(0);
+  t.equals(firstItem.innerHTML, 'This is a test', 'the rendered text is correct when rendering an error');
+  t.end();
+})
+
 // close the smokestack window once tests are complete
 test('shutdown', function(t) {
   t.end();


### PR DESCRIPTION
This PR adds a new method `renderError` to the suggestion class. `renderError` can be used to render arbitrary text (instead of objects, like render). This is useful for, example, to render error messages or to inform the user that their search returned no results. 

This is needed for https://github.com/mapbox/mapbox-gl-geocoder/issues/231 and https://github.com/mapbox/mapbox-gl-geocoder/issues/232.

