### PR TITLE
Fixed casing 'use strict'

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -1,4 +1,4 @@
-'Use strict';
+'use strict';
 
 var List = function(component) {
   this.component = component;


### PR DESCRIPTION
Casing in use strict causes rollup to throw a warning.