### PR TITLE
Only add to window if window exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,4 +56,8 @@
  * new Suggestions(input, data);
  */
 var Suggestions = require('./src/suggestions');
-window.Suggestions = module.exports = Suggestions;
+module.exports = Suggestions;
+
+if (typeof window !== 'undefined') {
+  window.Suggestions = Suggestions;
+}


### PR DESCRIPTION
This prevents `window is not defined` error when using SSR frameworks such as Next.js.

Sample Next.js app that demonstrates error when trying to import `suggestions` module: https://github.com/SamSamskies/suggestions-demo

Screenshot of error:
<img width="986" alt="Screen Shot 2020-09-08 at 2 36 04 PM" src="https://user-images.githubusercontent.com/3655410/92530166-b5020c00-f1e0-11ea-9d06-06ab1f09aa89.png">